### PR TITLE
After installing, it doesn't have valid dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   },
   "homepage": "https://github.com/Granze/react-starterify",
   "dependencies": {
+    "history": "1.13.1",
     "react": "^0.14.0",
     "react-dom": "^0.14.0",
     "react-router": "^1.0.0-rc3"


### PR DESCRIPTION
After npm install:

```
npm WARN EPEERINVALID react-router@1.0.2 requires a peer of history@1.13.x but none was installed.
```

And then running the tests:
```
➜  ~/zoo/zooniverse-status  npm test
> react-starterify@2.0.0 test /Users/marten/zoo/zooniverse-status
> mocha --reporter nyan --compilers js:babel/register --recursive

Warning: require('react/addons') is deprecated. Access using require('react-addons-{addon}') instead.
module.js:329
    throw err;
    ^

Error: Cannot find module 'history/lib/createHashHistory'
[...]
npm ERR! Test failed.  See above for more details.
```