### PR TITLE
print GTM variable w/o escaping HTML special characters

### DIFF
--- a/src/index.tpl.html
+++ b/src/index.tpl.html
@@ -9,6 +9,6 @@
   </head>
   <body>
     <div id="root"></div>
-    {%= o.htmlWebpackPlugin.options.gtm %}
+    {%# o.htmlWebpackPlugin.options.gtm %}
   </body>
 </html>


### PR DESCRIPTION
To print the GTM variable without escaping HTML special characters, I subbed `%=` with `%#` on L12 of `src/index.tpl.html` ([JavaScript Templates](https://github.com/blueimp/JavaScript-Templates#templates-syntax)). 