### PR TITLE
Airbnb Style Guide via ESLint

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,2 @@
+dist
+node_modules

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,5 +1,6 @@
 {
   "parser": "babel-eslint",
+  "extends": "airbnb",
   "plugins": [
     "react"
   ],

--- a/.eslintrc
+++ b/.eslintrc
@@ -24,6 +24,12 @@
       "smart"
     ],
     "space-after-keywords": 2,
-    "no-console": 1
+    "no-console": 1,
+    // specify the maximum length of a line in your program
+    // https://github.com/eslint/eslint/blob/master/docs/rules/max-len.md
+    'max-len': [1, 100, 2, {
+      'ignoreUrls': true,
+      'ignoreComments': false
+    }]
   }
 }

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "scripts": {
     "start": "babel-node server.js",
     "test": "",
+    "eslint": "eslint .",
     "build": "webpack --config webpack.production.config.js -p"
   },
   "author": "Zooniverse",
@@ -51,9 +52,10 @@
     "clean-webpack-plugin": "^0.1.6",
     "css-loader": "^0.23.1",
     "eslint": "^1.10.3",
+    "eslint-config-airbnb": "^3.1.0",
     "eslint-loader": "^1.1.1",
-    "eslint-plugin-react": "^3.3.2",
     "eventsource-polyfill": "^0.9.6",
+    "eslint-plugin-react": "^3.15.0",
     "express": "^4.13.3",
     "extract-text-webpack-plugin": "^0.9.1",
     "file-loader": "^0.8.5",

--- a/server.js
+++ b/server.js
@@ -6,14 +6,14 @@ import webpackMiddleware from 'webpack-dev-middleware';
 import webpackHotMiddleware from 'webpack-hot-middleware';
 import config from './webpack.config.js';
 
-var isProduction = process.env.NODE_ENV === 'production';
-var port = isProduction ? process.env.PORT : 3000;
-var app = express();
-var indexHtml = path.join(__dirname, 'dist/index.html');
+const isProduction = process.env.NODE_ENV === 'production';
+const port = isProduction ? process.env.PORT : 3000;
+const app = express();
+const indexHtml = path.join(__dirname, 'dist/index.html');
 
 if (!isProduction) {
-  var compiler = webpack(config);
-  var middleware = webpackMiddleware(compiler, {
+  const compiler = webpack(config);
+  const middleware = webpackMiddleware(compiler, {
     publicPath: config.output.publicPath,
     contentBase: 'src',
     stats: {

--- a/src/Index.js
+++ b/src/Index.js
@@ -5,7 +5,7 @@ import App from './components/App';
 import PoweredBy from './components/Powered-by';
 import About from './components/About';
 
-import Styles from './styles/main.styl'
+import Styles from './styles/main.styl';
 
 window.React = React;
 

--- a/src/Index.js
+++ b/src/Index.js
@@ -5,6 +5,9 @@ import App from './components/App';
 import PoweredBy from './components/Powered-by';
 import About from './components/About';
 
+// Todo: let's find a better way to include Styles,
+// currently Styles looks like an unused var to eslint
+/* eslint "no-unused-vars": 1 */
 import Styles from './styles/main.styl';
 
 window.React = React;

--- a/src/components/About.js
+++ b/src/components/About.js
@@ -6,8 +6,7 @@ export default class About extends React.Component {
       <div>
         <h2>About</h2>
         <p>React Starterify aims to give you a good starting point for your projects.</p>
-        <p>If you're looking for a minimal ES6 (ES2015) React JS starter with nice
-        shallow rendering test examples, this is probably for you.</p>
+        <p>If you're looking for a minimal ES6 (ES2015) React JS starter with nice shallow rendering test examples, this is probably for you.</p>
       </div>
     );
   }

--- a/src/components/About.js
+++ b/src/components/About.js
@@ -1,14 +1,14 @@
 import React from 'react';
 
-export default React.createClass({
+export default class About extends React.Component {
   render() {
     return (
       <div>
         <h2>About</h2>
         <p>React Starterify aims to give you a good starting point for your projects.</p>
-        <p>If you're looking for a minimal ES6 (ES2015) React JS starter with nice shallow rendering test examples,
-        this is probably for you.</p>
+        <p>If you're looking for a minimal ES6 (ES2015) React JS starter with nice
+        shallow rendering test examples, this is probably for you.</p>
       </div>
     );
-  },
-});
+  }
+}

--- a/src/components/About.js
+++ b/src/components/About.js
@@ -6,8 +6,9 @@ export default React.createClass({
       <div>
         <h2>About</h2>
         <p>React Starterify aims to give you a good starting point for your projects.</p>
-        <p>If you're looking for a minimal ES6 (ES2015) React JS starter with nice shallow rendering test examples, this is probably for you.</p>
+        <p>If you're looking for a minimal ES6 (ES2015) React JS starter with nice shallow rendering test examples,
+        this is probably for you.</p>
       </div>
     );
-  }
+  },
 });

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -2,11 +2,12 @@ import React from 'react';
 import { Link } from 'react-router';
 import packageJSON from '../../package.json';
 
-export default React.createClass({
+
+export default class App extends React.Component {
   returnSomething(something) {
     // this is only for testing purposes. Check /test/components/App-test.js
     return something;
-  },
+  }
   render() {
     const version = packageJSON.version;
 
@@ -22,5 +23,8 @@ export default React.createClass({
         </section>
       </div>
     );
-  },
-});
+  }
+}
+App.propTypes = {
+  children: React.PropTypes.object,
+};

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -1,10 +1,10 @@
 import React from 'react';
-import { Link }  from 'react-router';
+import { Link } from 'react-router';
 import packageJSON from '../../package.json';
 
 export default React.createClass({
   returnSomething(something) {
-    //this is only for testing purposes. Check /test/components/App-test.js
+    // this is only for testing purposes. Check /test/components/App-test.js
     return something;
   },
   render() {
@@ -21,6 +21,6 @@ export default React.createClass({
           {this.props.children || 'Welcome to React Starterify'}
         </section>
       </div>
-    )
-  }
+    );
+  },
 });

--- a/src/components/Powered-by.js
+++ b/src/components/Powered-by.js
@@ -3,8 +3,8 @@ import packageJSON from '../../package.json';
 
 export default React.createClass({
   render() {
-    let deps = Object.keys(packageJSON.dependencies).map((dep, i) => <li key={i}>{dep}</li>);
-    let devDeps = Object.keys(packageJSON.devDependencies).map((dep, i) => <li key={i + 10}>{dep}</li>);
+    const deps = Object.keys(packageJSON.dependencies).map((dep, i) => <li key={i}>{dep}</li>);
+    const devDeps = Object.keys(packageJSON.devDependencies).map((dep, i) => <li key={i + 10}>{dep}</li>);
 
     return (
       <div>
@@ -16,5 +16,5 @@ export default React.createClass({
         </ul>
       </div>
     );
-  }
+  },
 });

--- a/src/components/Powered-by.js
+++ b/src/components/Powered-by.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import packageJSON from '../../package.json';
 
-export default React.createClass({
+export default class PoweredBy extends React.Component {
   render() {
     const deps = Object.keys(packageJSON.dependencies).map((dep, i) => <li key={i}>{dep}</li>);
     const devDeps = Object.keys(packageJSON.devDependencies).map((dep, i) => <li key={i + 10}>{dep}</li>);
@@ -16,5 +16,5 @@ export default React.createClass({
         </ul>
       </div>
     );
-  },
-});
+  }
+}

--- a/test/components/About-test.js
+++ b/test/components/About-test.js
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import About from '../../src/components/About';
 
 describe('About', () => {
-  const {TestUtils} = React.addons;
+  const { TestUtils } = React.addons;
   const shallowRenderer = TestUtils.createRenderer();
   shallowRenderer.render(<About />);
   const about = shallowRenderer.getRenderOutput();
@@ -15,5 +15,4 @@ describe('About', () => {
   it('should have an h2 tag containing the text "About"', () => {
     expect(about.props.children).to.contain(<h2>About</h2>);
   });
-
 });

--- a/test/components/App-test.js
+++ b/test/components/App-test.js
@@ -4,7 +4,7 @@ import App from '../../src/components/App';
 import * as packageJSON from '../../package.json';
 
 describe('App', () => {
-  const {TestUtils} = React.addons;
+  const { TestUtils } = React.addons;
   const shallowRenderer = TestUtils.createRenderer();
   shallowRenderer.render(<App />);
   const app = shallowRenderer.getRenderOutput();
@@ -14,16 +14,15 @@ describe('App', () => {
   });
 
   it('should have a version number that match the package.json version property', () => {
-    let version = packageJSON.version;
-    let h1 = app.props.children[0].props.children;
+    const version = packageJSON.version;
+    const h1 = app.props.children[0].props.children;
 
     expect(h1).to.include(<h1 className="title">React Starterify {version}</h1>);
   });
 
   it('should return something', () => {
-    let returnSomething = App.prototype.returnSomething('hello!');
+    const returnSomething = App.prototype.returnSomething('hello!');
 
     expect(returnSomething).to.be.equal('hello!');
   });
-
 });

--- a/test/components/Powered-by-test.js
+++ b/test/components/Powered-by-test.js
@@ -4,7 +4,7 @@ import Poweredby from '../../src/components/Powered-by';
 import * as packageJSON from '../../package.json';
 
 describe('Powered by', () => {
-  const {TestUtils} = React.addons;
+  const { TestUtils } = React.addons;
   const shallowRenderer = TestUtils.createRenderer();
   shallowRenderer.render(<Poweredby />);
   const poweredBy = shallowRenderer.getRenderOutput();
@@ -14,18 +14,17 @@ describe('Powered by', () => {
   });
 
   it('should render the deps list and "react" should be present', () => {
-    let ul = poweredBy.props.children.filter(c => c.type === 'ul');
-    let li = ul[0].props.children[1].props.children;
+    const ul = poweredBy.props.children.filter(c => c.type === 'ul');
+    const li = ul[0].props.children[1].props.children;
 
     expect(li).to.equal('react');
   });
 
   it('should display all the dependencies and dev dependencies', () => {
-    let ul = poweredBy.props.children.filter(c => c.type === 'ul');
-    let renderedDeps = ul[0].props.children.length;
-    let npmDeps = Object.keys(packageJSON.dependencies).length + Object.keys(packageJSON.devDependencies).length;
+    const ul = poweredBy.props.children.filter(c => c.type === 'ul');
+    const renderedDeps = ul[0].props.children.length;
+    const npmDeps = Object.keys(packageJSON.dependencies).length + Object.keys(packageJSON.devDependencies).length;
 
     expect(renderedDeps).to.be.equal(npmDeps);
   });
-
 });

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -40,13 +40,13 @@ module.exports = {
   },
 
   module: {
-    preLoaders: [
-      {
-        test: /\.jsx?$/,
-        exclude: /node_modules/,
-        loader: 'eslint-loader',
-      },
-    ],
+    // preLoaders: [
+    //   {
+    //     test: /\.jsx?$/,
+    //     exclude: /node_modules/,
+    //     loader: 'eslint-loader',
+    //   },
+    // ],
     loaders: [
       {
         test: /\.json$/,
@@ -70,5 +70,5 @@ module.exports = {
 
   stylus: {
     use: [nib()],
-  }
+  },
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,3 @@
-'use strict';
-
 import path from 'path';
 import webpack from 'webpack';
 import HtmlWebpackPlugin from 'html-webpack-plugin';
@@ -42,13 +40,13 @@ module.exports = {
   },
 
   module: {
-    preLoaders: [
-      {
-        test: /\.jsx?$/,
-        exclude: /node_modules/,
-        loader: 'eslint-loader',
-      },
-    ],
+    // preLoaders: [
+    //   {
+    //     test: /\.jsx?$/,
+    //     exclude: /node_modules/,
+    //     loader: 'eslint-loader',
+    //   },
+    // ],
     loaders: [
       {
         test: /\.json$/,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -40,13 +40,13 @@ module.exports = {
   },
 
   module: {
-    // preLoaders: [
-    //   {
-    //     test: /\.jsx?$/,
-    //     exclude: /node_modules/,
-    //     loader: 'eslint-loader',
-    //   },
-    // ],
+    preLoaders: [
+      {
+        test: /\.jsx?$/,
+        exclude: /node_modules/,
+        loader: 'eslint-loader',
+      },
+    ],
     loaders: [
       {
         test: /\.json$/,

--- a/webpack.production.config.js
+++ b/webpack.production.config.js
@@ -26,7 +26,7 @@ module.exports = {
       filename: 'index.html',
       gtm: '<noscript><iframe src=\"//www.googletagmanager.com/ns.html?id=GTM-WDW6V4\" height=\"0\" width=\"0\" style=\"display:none;visibility:hidden\"></iframe></noscript><script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({\"gtm.start\":new Date().getTime(),event:\"gtm.js\"});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!=\"dataLayer\"?\"&l=\"+l:\"\";j.async=true;j.src=\"//www.googletagmanager.com/gtm.js?id=\"+i+dl;f.parentNode.insertBefore(j,f);})(window,document,\"script\",\"dataLayer\",\"GTM-WDW6V4\");</script>',
     }),
-    new ExtractTextPlugin('[name]-[hash].min.css', {allChunks: true}),
+    new ExtractTextPlugin('[name]-[hash].min.css', { allChunks: true }),
     new webpack.optimize.UglifyJsPlugin({
       compressor: {
         warnings: false,
@@ -68,7 +68,7 @@ module.exports = {
       },
       {
         test: /\.(jpg|png|gif|otf|eot|svg|ttf|woff\d?)$/,
-        loaders: ['file-loader', 'image-webpack']
+        loaders: ['file-loader', 'image-webpack'],
       },
     ],
   },

--- a/webpack.production.config.js
+++ b/webpack.production.config.js
@@ -1,12 +1,10 @@
-'use strict';
-
-var path = require('path');
-var webpack = require('webpack');
-var HtmlWebpackPlugin = require('html-webpack-plugin');
-var ExtractTextPlugin = require('extract-text-webpack-plugin');
-var StatsPlugin = require('stats-webpack-plugin');
-var nib = require('nib');
-var CleanWebpackPlugin = require('clean-webpack-plugin');
+const path = require('path');
+const webpack = require('webpack');
+const HtmlWebpackPlugin = require('html-webpack-plugin');
+const ExtractTextPlugin = require('extract-text-webpack-plugin');
+const StatsPlugin = require('stats-webpack-plugin');
+const nib = require('nib');
+const CleanWebpackPlugin = require('clean-webpack-plugin');
 
 module.exports = {
 


### PR DESCRIPTION
This PR adds [eslint-config-airbnb](https://github.com/airbnb/javascript/tree/master/packages/eslint-config-airbnb#eslint-config-airbnb-1). As suggested in Issue #5, we can modify and remove rules as needed in `zoo-react-starterify/.eslintrc`. 

To run the lint rules, you can use the following npm script: `npm run eslint`. 

In addition, the eslint rules are checked using the [`preLoaders`](https://github.com/zooniverse/zoo-react-starterify/blob/airbnb-style-guide/webpack.config.js#L42-L47) section of `webpack.config.js`.