### PR TITLE
Remove bitHound.io from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-[![bitHound Score](https://www.bithound.io/github/Granze/react-starterify/badges/score.svg)](https://www.bithound.io/github/zooniverse/zoo-react-starterify/master)
-
 # Zooniverse React Starterify
 
 A minimal React JS application starter kit, based on [React Starterify](https://github.com/Granze/react-starterify).


### PR DESCRIPTION
## PR Overview
This PR removes the bitHound.io badge from the README, because bitHound.io has shut down and the badge is no longer relevant. Note: the embed was also showing the wrong badge.